### PR TITLE
Fix a syntax error.

### DIFF
--- a/.tmux.conf
+++ b/.tmux.conf
@@ -5,7 +5,7 @@
 # -- general -------------------------------------------------------------------
 
 set -g default-terminal "screen-256color" # colors!
-setw -g xterm-keys on
+set -g xterm-keys on
 set -s escape-time 0                      # fastest command sequences
 set -sg repeat-time 600                   # increase repeat timeout
 set -s quiet on                           # disable various messages


### PR DESCRIPTION
Fixes `/Users/mz/.tmux.conf:8: command not found: setw` error as mentioned in #25.