### PR TITLE
Add vim mode for yank and begin-selection

### DIFF
--- a/.tmux.conf
+++ b/.tmux.conf
@@ -9,6 +9,7 @@ setw -g xterm-keys on
 set -s escape-time 0                      # fastest command sequences
 set -sg repeat-time 600                   # increase repeat timeout
 set -s quiet on                           # disable various messages
+set -g mode-keys vi                       # set vim mode for yank and begin-selection
 
 set -g prefix2 C-a                        # GNU-Screen compatible prefix
 bind C-a send-prefix -2


### PR DESCRIPTION
In Mac OSX 10.11.6 El Capitan, if is not set mode-keys for vi then I can't perform begin-selection (v) or yank (y) in vim-mode.
Cheers