### PR TITLE
Use powershell to scrape battery data from win32_battery api ...

### DIFF
--- a/.tmux.conf
+++ b/.tmux.conf
@@ -235,6 +235,7 @@ run 'cut -c3- ~/.tmux.conf | sh -s _apply_configuration'
 #
 # _battery() {
 #   uname_s=$(uname -s)
+#   uname_a=$(uname -a)
 #   case "$uname_s" in
 #     *Darwin*)
 #       batt=$(pmset -g batt)
@@ -243,21 +244,29 @@ run 'cut -c3- ~/.tmux.conf | sh -s _apply_configuration'
 #       charge="${percentage%%%} / 100"
 #       ;;
 #     *Linux*)
-#       batpath=/sys/class/power_supply/BAT0
-#       if [ ! -d $batpath ]; then
-#         batpath=/sys/class/power_supply/BAT1
-#       fi
-#       discharging=$(grep -qi "discharging" $batpath/status && echo "true" || echo "false")
-#       bat_capacity=$batpath/capacity
-#       bat_energy_full=$batpath/energy_full
-#       bat_energy_now=$batpath/energy_now
-#       if [ -r "$bat_capacity" ]; then
-#         charge="$(cat $bat_capacity) / 100"
+#       if echo $uname_a | grep -q "Microsoft"; then
+#         # Bash on ubuntu on windows
+#         discharging=$(powershell.exe "(Get-WmiObject win32_battery).BatteryStatus" | grep -q 1 && echo "true" || echo "false")
+#         percentage=$(powershell.exe "(Get-WmiObject win32_battery).estimatedChargeRemaining")
+#         charge="${percentage} / 100"
 #       else
-#         if [ ! -r "$bat_energy_full" ] || [ ! -r "$bat_energy_now" ]; then
-#           return
+#         # Linux
+#         batpath=/sys/class/power_supply/BAT0
+#         if [ ! -d $batpath ]; then
+#           batpath=/sys/class/power_supply/BAT1
 #         fi
-#         charge="$(cat $bat_energy_now) / $(cat $bat_energy_full)" || return
+#         discharging=$(grep -qi "discharging" $batpath/status && echo "true" || echo "false")
+#         bat_capacity=$batpath/capacity
+#         bat_energy_full=$batpath/energy_full
+#         bat_energy_now=$batpath/energy_now
+#         if [ -r "$bat_capacity" ]; then
+#           charge="$(cat $bat_capacity) / 100"
+#         else
+#           if [ ! -r "$bat_energy_full" ] || [ ! -r "$bat_energy_now" ]; then
+#             return
+#           fi
+#           charge="$(cat $bat_energy_now) / $(cat $bat_energy_full)" || return
+#         fi
 #       fi
 #       ;;
 #     *CYGWIN*)


### PR DESCRIPTION
to support .tmux.conf battery in Windows Subsystem for Linux (BASH on Windows)

Tested on Win10 + Ubuntu 16.04 in WSL. Uses uname -a and "Microsoft" to differentiate between regular Ubuntu and Windows Ubuntu.