### PR TITLE
Fixed missing vi-copy / copy-mode-vi H/L keybindings.

### DIFF
--- a/.tmux.conf
+++ b/.tmux.conf
@@ -139,6 +139,8 @@ run -b 'tmux bind -T copy-mode-vi y send -X copy-selection-and-cancel 2> /dev/nu
 run -b 'tmux bind -t vi-copy Escape cancel 2> /dev/null || true'
 run -b 'tmux bind -T copy-mode-vi Escape send -X cancel 2> /dev/null || true'
 run -b 'tmux bind -t vi-copy H start-of-line 2> /dev/null || true'
+run -b 'tmux bind -T copy-mode-vi H send -X start-of-line 2> /dev/null || true'
+run -b 'tmux bind -t vi-copy L end-of-line 2> /dev/null || true'
 run -b 'tmux bind -T copy-mode-vi L send -X end-of-line 2> /dev/null || true'
 
 # copy to Mac OSX clipboard


### PR DESCRIPTION
Added the missing H/L keybindings to the vi-copy / copy-mode-vi modes configurations.