### PR TITLE
remove line breaks from base64'd clipboard content

### DIFF
--- a/.tmux.conf
+++ b/.tmux.conf
@@ -453,60 +453,87 @@ run 'cut -c3- ~/.tmux.conf | sh -s _apply_configuration'
 #         set -g '@battery_percentage' "$battery_percentage"
 # }
 #
+# _tty_info() {
+#   tty="${1##/dev/}"
+#   uname -s | grep -q "CYGWIN" && cygwin=true
+#
+#   if [ x"$cygwin" = x"true" ]; then
+#     ps -af | tail -n +2 | awk -v tty="$tty" '
+#       $4 == tty { user[$2] = $1; child[$3] = $2 }
+#       END {
+#         for (i in user)
+#         {
+#           if (!(i in child))
+#           {
+#             file = "/proc/" i "/cmdline"; getline command < file; close(file)
+#             gsub(/\0/, " ", command)
+#             print i, user[i], command
+#             exit
+#           }
+#         }
+#       }
+#     '
+#   else
+#     ps -t "$tty" -o user= -o pid= -o ppid= -o command= | awk '
+#       { user[$2] = $1; child[$3] = $2; for (i = 4 ; i <= NF; ++i) command[$2] = i > 4 ? command[$2] FS $i : $i }
+#       END {
+#         for (i in user)
+#         {
+#           if (!(i in child))
+#           {
+#             print i, user[i], command[i]
+#             exit
+#           }
+#         }
+#       }
+#     '
+#   fi
+# }
+#
+# _ssh_or_mosh_args() {
+#   args=$(printf '%s' "$1" | awk '/ssh/ && !/vagrant ssh/ && !/autossh/ && !/-W/ { $1=""; print $0; exit }')
+#   if [ -z "$args" ]; then
+#     args=$(printf '%s' "$1" | grep 'mosh-client' | sed -E -e 's/.*mosh-client -# (.*)\|.*$/\1/' -e 's/-[^ ]*//g' -e 's/\d:\d//g')
+#   fi
+#
+#  printf '%s' "$args"
+# }
+#
 # _username() {
 #   tty=${1:-$(tmux display -p '#{pane_tty}')}
 #   ssh_only=$2
-#   # shellcheck disable=SC2039
-#   if [ x"$OSTYPE" = x"cygwin" ]; then
-#     pid=$(ps -a | awk -v tty="${tty##/dev/}" '$5 == tty && /ssh/ && !/vagrant ssh/ && !/autossh/ && !/-W/ { print $1 }')
-#     [ -n "$pid" ] && ssh_parameters=$(tr '\0' ' ' < "/proc/$pid/cmdline" | sed 's/^ssh //')
-#   else
-#     ssh_parameters=$(ps -t "$tty" -o command= | awk '/ssh/ && !/vagrant ssh/ && !/autossh/ && !/-W/ { $1=""; print $0; exit }')
-#   fi
-#   if [ -n "$ssh_parameters" ]; then
+#
+#   tty_info=$(_tty_info "$tty")
+#   command=$(printf '%s' "$tty_info" | cut -d' ' -f3-)
+#
+#   ssh_or_mosh_args=$(_ssh_or_mosh_args "$command")
+#   if [ -n "$ssh_or_mosh_args" ]; then
 #     # shellcheck disable=SC2086
-#     username=$(ssh -G $ssh_parameters 2>/dev/null | awk 'NR > 2 { exit } ; /^user / { print $2 }')
+#     username=$(ssh -G $ssh_or_mosh_args 2>/dev/null | awk 'NR > 2 { exit } ; /^user / { print $2 }')
 #     # shellcheck disable=SC2086
-#     [ -z "$username" ] && username=$(ssh -T -o ControlPath=none -o ProxyCommand="sh -c 'echo %%username%% %r >&2'" $ssh_parameters 2>&1 | awk '/^%username% / { print $2; exit }')
+#     [ -z "$username" ] && username=$(ssh -T -o ControlPath=none -o ProxyCommand="sh -c 'echo %%username%% %r >&2'" $ssh_or_mosh_args 2>&1 | awk '/^%username% / { print $2; exit }')
 #   else
 #     if ! _is_enabled "$ssh_only"; then
-#       # shellcheck disable=SC2039
-#       if [ x"$OSTYPE" = x"cygwin" ]; then
-#         username=$(whoami)
-#       else
-#         username=$(ps -t "$tty" -o user= -o pid= -o ppid= -o command= | awk '
-#           !/ssh/ { user[$2] = $1; ppid[$3] = 1 }
-#           END {
-#             for (i in user)
-#               if (!(i in ppid))
-#               {
-#                 print user[i]
-#                 exit
-#               }
-#           }
-#         ')
-#       fi
+#       username=$(printf '%s' "$tty_info" | cut -d' ' -f2)
 #     fi
 #   fi
 #
-#   echo "$username"
+#   printf '%s' "$username"
 # }
 #
 # _hostname() {
 #   tty=${1:-$(tmux display -p '#{pane_tty}')}
 #   ssh_only=$2
-#   # shellcheck disable=SC2039
-#   if [ x"$OSTYPE" = x"cygwin" ]; then
-#     pid=$(ps -a | awk -v tty="${tty##/dev/}" '$5 == tty && /ssh/ && !/vagrant ssh/ && !/autossh/ && !/-W/ { print $1 }')
-#     [ -n "$pid" ] && ssh_parameters=$(tr '\0' ' ' < "/proc/$pid/cmdline" | sed 's/^ssh //')
-#   else
-#     ssh_parameters=$(ps -t "$tty" -o command= | awk '/ssh/ && !/vagrant ssh/ && !/autossh/ && !/-W/ { $1=""; print $0; exit }')
-#   fi
-#   if [ -n "$ssh_parameters" ]; then
+#
+#   tty_info=$(_tty_info "$tty")
+#   command=$(printf '%s' "$tty_info" | cut -d' ' -f3-)
+#
+#   ssh_or_mosh_args=$(_ssh_or_mosh_args "$command")
+#   if [ -n "$ssh_or_mosh_args" ]; then
 #     # shellcheck disable=SC2086
-#     hostname=$(ssh -G $ssh_parameters 2>/dev/null | awk 'NR > 2 { exit } ; /^hostname / { print $2 }')
+#     hostname=$(ssh -G $ssh_or_mosh_args 2>/dev/null | awk 'NR > 2 { exit } ; /^hostname / { print $2 }')
 #     # shellcheck disable=SC2086
-#     [ -z "$hostname" ] && hostname=$(ssh -T -o ControlPath=none -o ProxyCommand="sh -c 'echo %%hostname%% %h >&2'" $ssh_parameters 2>&1 | awk '/^%hostname% / { print $2; exit }')
+#     [ -z "$hostname" ] && hostname=$(ssh -T -o ControlPath=none -o ProxyCommand="sh -c 'echo %%hostname%% %h >&2'" $ssh_or_mosh_args 2>&1 | awk '/^%hostname% / { print $2; exit }')
 #     #shellcheck disable=SC1004
 #     hostname=$(echo "$hostname" | awk '\
 #     { \
@@ -521,7 +548,7 @@ run 'cut -c3- ~/.tmux.conf | sh -s _apply_configuration'
 #     fi
 #   fi
 #
-#   echo "$hostname"
+#   printf '%s' "$hostname"
 # }
 #
 # _root() {
@@ -581,19 +608,22 @@ run 'cut -c3- ~/.tmux.conf | sh -s _apply_configuration'
 # _split_window() {
 #   tty=${1:-$(tmux display -p '#{pane_tty}')}
 #   shift
-#   # shellcheck disable=SC2039
-#   if [ x"$OSTYPE" = x"cygwin" ]; then
-#     pid=$(ps -a | sort -d | awk -v tty="${tty##/dev/}" '$5 == tty && /ssh/ && !/-W/ { print $1; exit 0 }')
-#     [ -n "$pid" ] && ssh=$(tr '\0' ' ' < "/proc/$pid/cmdline")
-#   else
-#     ssh=$(ps -t "$tty" -o command= | sort -d | awk '/ssh/ && !/-W/ { print $0; exit 0 }')
-#   fi
-#   if [ -n "$ssh" ]; then
-#     # shellcheck disable=SC2046
-#     tmux split-window "$@" $(echo "$ssh" | sed -e "s/;/\\\\;/g")
-#   else
-#     tmux split-window "$@"
-#   fi
+#
+#   tty_info=$(_tty_info "$tty")
+#   command=$(printf '%s' "$tty_info" | cut -d' ' -f3-)
+#
+#   case "$command" in
+#     *mosh-client*)
+#       # shellcheck disable=SC2046
+#        tmux split-window "$@" mosh $(echo "$command" | sed -E -e 's/.*mosh-client -# (.*)\|.*$/\1/')
+#      ;;
+#     *ssh*)
+#       # shellcheck disable=SC2046
+#       tmux split-window "$@" $(echo "$command" | sed -e 's/;/\\\\;/g')
+#       ;;
+#     *)
+#       tmux split-window "$@"
+#   esac
 # }
 #
 # _apply_overrides() {

--- a/.tmux.conf
+++ b/.tmux.conf
@@ -142,16 +142,8 @@ run -b 'tmux bind -T copy-mode-vi H send -X start-of-line 2> /dev/null || true'
 run -b 'tmux bind -t vi-copy L end-of-line 2> /dev/null || true'
 run -b 'tmux bind -T copy-mode-vi L send -X end-of-line 2> /dev/null || true'
 
-# copy to OS clipboard with OSC 52 escape sequence
+# copy to OS clipboard
 bind y run -b 'cut -c3- ~/.tmux.conf | sh -s _copy #{pane_tty}'
-# copy to Mac OSX clipboard
-if -b 'command -v reattach-to-user-namespace > /dev/null 2>&1' 'bind y run -b "tmux save-buffer - | reattach-to-user-namespace pbcopy"'
-# copy to X11 clipboard
-if -b 'command -v xsel > /dev/null 2>&1' 'bind y run -b "tmux save-buffer - | xsel -i -b"'
-if -b '! command -v xsel > /dev/null 2>&1 && command -v xclip > /dev/null 2>&1' 'bind y run -b "tmux save-buffer - | xclip -i -selection clipboard >/dev/null 2>&1"'
-# copy to Windows clipboard
-if -b 'command -v clip.exe > /dev/null 2>&1' 'bind y run -b "tmux save-buffer - | clip.exe"'
-if -b '[ -c /dev/clipboard ]' 'bind y run -b "tmux save-buffer - > /dev/clipboard"'
 
 
 # -- buffers -------------------------------------------------------------------
@@ -630,7 +622,8 @@ run 'cut -c3- ~/.tmux.conf | sh -s _apply_configuration'
 #
 # _copy() {
 #   tty="$SSH_TTY"
-#   tty=${1:-$(tmux display -p '#{pane_tty}')}
+#   tty=${tty:-$1}
+#   tty=${tty:-$(tmux display -p '#{pane_tty}')}
 #   buffer=${2:-$(tmux save-buffer -)}
 #
 #   if [ "$tty" != "$SSH_TTY" ]; then

--- a/.tmux.conf
+++ b/.tmux.conf
@@ -143,7 +143,7 @@ run -b 'tmux bind -t vi-copy L end-of-line 2> /dev/null || true'
 run -b 'tmux bind -T copy-mode-vi L send -X end-of-line 2> /dev/null || true'
 
 # copy to OS clipboard with OSC 52 escape sequence
-bind y run -b 'cut -c3- ~/.tmux.conf | sh -s _osc52 #{pane_tty}'
+bind y run -b 'cut -c3- ~/.tmux.conf | sh -s _copy #{pane_tty}'
 # copy to Mac OSX clipboard
 if -b 'command -v reattach-to-user-namespace > /dev/null 2>&1' 'bind y run -b "tmux save-buffer - | reattach-to-user-namespace pbcopy"'
 # copy to X11 clipboard
@@ -628,10 +628,25 @@ run 'cut -c3- ~/.tmux.conf | sh -s _apply_configuration'
 #   esac
 # }
 #
-# _osc52() {
+# _copy() {
 #   tty="$SSH_TTY"
 #   tty=${1:-$(tmux display -p '#{pane_tty}')}
 #   buffer=${2:-$(tmux save-buffer -)}
+#
+#   if [ "$tty" != "$SSH_TTY" ]; then
+#     command -v pbcopy > /dev/null 2>&1 && command='pbcopy'
+#     command -v reattach-to-user-namespace > /dev/null 2>&1 && command='reattach-to-user-namespace pbcopy'
+#     command -v xsel > /dev/null 2>&1 && command='xsel -i -b'
+#     ! command -v xsel > /dev/null 2>&1 && command -v xclip > /dev/null 2>&1 && command='xclip -i -selection clipboard > \/dev\/null 2>\&1'
+#     command -v clip.exe > /dev/null 2>&1 && command='clip\.exe'
+#     [ -c /dev/clipboard ] && command='cat > \/dev\/clipboard'
+#
+#     if [ -n "$command" ]; then
+#       printf %s "$buffer" | $command
+#       return
+#     fi
+#   fi
+#
 #   printf "\033Ptmux;\033\033]52;c;%s\a\033\\" "$(printf %s "$buffer" | base64)" > "$tty"
 # }
 #

--- a/.tmux.conf
+++ b/.tmux.conf
@@ -623,10 +623,14 @@ run 'cut -c3- ~/.tmux.conf | sh -s _apply_configuration'
 # }
 #
 # _copy() {
+#   exec 2> /tmp/log.txt
+#   set -x
 #   tty="$SSH_TTY"
 #   tty=${tty:-$1}
 #   tty=${tty:-$(tmux display -p '#{pane_tty}')}
-#   buffer=${2:-$(tmux save-buffer -)}
+#   buffer=${2:-$(tmux save-buffer - || true)}
+#
+#   [ -z "$buffer" ] && return
 #
 #   if [ "$tty" != "$SSH_TTY" ]; then
 #     command -v pbcopy > /dev/null 2>&1 && command='pbcopy'
@@ -643,6 +647,7 @@ run 'cut -c3- ~/.tmux.conf | sh -s _apply_configuration'
 #   fi
 #
 #   printf '\033Ptmux;\033\033]52;c;%s\a\033\\' "$(printf %s "$buffer" | head -c 74994 | base64)" > "$tty"
+#   set +x
 # }
 #
 # _apply_overrides() {

--- a/.tmux.conf
+++ b/.tmux.conf
@@ -15,6 +15,8 @@ set -s escape-time 10                     # faster command sequences
 set -sg repeat-time 600                   # increase repeat timeout
 set -s focus-events on
 
+set -ga update-environment SSH_TTY        # OSC 52 escape sequence receiver
+
 set -g prefix2 C-a                        # GNU-Screen compatible prefix
 bind C-a send-prefix -2
 
@@ -640,7 +642,7 @@ run 'cut -c3- ~/.tmux.conf | sh -s _apply_configuration'
 #     fi
 #   fi
 #
-#   printf "\033Ptmux;\033\033]52;c;%s\a\033\\" "$(printf %s "$buffer" | base64)" > "$tty"
+#   printf '\033Ptmux;\033\033]52;c;%s\a\033\\' "$(printf %s "$buffer" | base64)" > "$tty"
 # }
 #
 # _apply_overrides() {

--- a/.tmux.conf
+++ b/.tmux.conf
@@ -142,6 +142,8 @@ run -b 'tmux bind -T copy-mode-vi H send -X start-of-line 2> /dev/null || true'
 run -b 'tmux bind -t vi-copy L end-of-line 2> /dev/null || true'
 run -b 'tmux bind -T copy-mode-vi L send -X end-of-line 2> /dev/null || true'
 
+# copy to OS clipboard with OSC 52 escape sequence
+bind y run -b 'cut -c3- ~/.tmux.conf | sh -s _osc52 #{pane_tty}'
 # copy to Mac OSX clipboard
 if -b 'command -v reattach-to-user-namespace > /dev/null 2>&1' 'bind y run -b "tmux save-buffer - | reattach-to-user-namespace pbcopy"'
 # copy to X11 clipboard
@@ -624,6 +626,13 @@ run 'cut -c3- ~/.tmux.conf | sh -s _apply_configuration'
 #     *)
 #       tmux split-window "$@"
 #   esac
+# }
+#
+# _osc52() {
+#   tty="$SSH_TTY"
+#   tty=${1:-$(tmux display -p '#{pane_tty}')}
+#   buffer=${2:-$(tmux save-buffer -)}
+#   printf "\033Ptmux;\033\033]52;c;%s\a\033\\" "$(printf %s "$buffer" | base64)" > "$tty"
 # }
 #
 # _apply_overrides() {

--- a/.tmux.conf
+++ b/.tmux.conf
@@ -642,7 +642,7 @@ run 'cut -c3- ~/.tmux.conf | sh -s _apply_configuration'
 #     fi
 #   fi
 #
-#   printf '\033Ptmux;\033\033]52;c;%s\a\033\\' "$(printf %s "$buffer" | base64)" > "$tty"
+#   printf '\033Ptmux;\033\033]52;c;%s\a\033\\' "$(printf %s "$buffer" | head -c 74994 | base64)" > "$tty"
 # }
 #
 # _apply_overrides() {

--- a/.tmux.conf
+++ b/.tmux.conf
@@ -720,35 +720,26 @@ run 'cut -c3- ~/.tmux.conf | sh -s _apply_configuration'
 # EOF
 #
 #   tmux_conf_copy_to_os_clipboard=${tmux_conf_copy_to_os_clipboard:-false}
-#   command -v pbcopy > /dev/null 2>&1 && command='pbcopy'
-#   command -v reattach-to-user-namespace > /dev/null 2>&1 && command='reattach-to-user-namespace pbcopy'
-#   command -v xsel > /dev/null 2>&1 && command='xsel -i -b'
-#   ! command -v xsel > /dev/null 2>&1 && command -v xclip > /dev/null 2>&1 && command='xclip -i -selection clipboard > \/dev\/null 2>\&1'
-#   command -v clip.exe > /dev/null 2>&1 && command='clip\.exe'
-#   [ -c /dev/clipboard ] && command='cat > \/dev\/clipboard'
+#   # shellcheck disable=SC2086
+#   for table in "" "-t emacs-copy" "-t vi-copy"; do
+#     line=$(tmux list-keys $table 2>/dev/null | grep -e 'copy-selection\|append-selection' | head -1)
+#     [ -z "$line" ] && continue
+#     prefix=${line%copy-*}
+#     column=${#prefix}
 #
-#   if [ -n "$command" ]; then
-#     # shellcheck disable=SC2086
-#     for table in "" "-t emacs-copy" "-t vi-copy"; do
-#       line=$(tmux list-keys $table 2>/dev/null | grep -e 'copy-selection\|copy-pipe' | head -1)
-#       prefix=${line%copy-*}
-#       column=${#prefix}
+#     while IFS= read -r line; do
 #       [ -z "$line" ] && continue
-#
-#       while IFS= read -r line; do
-#         [ -z "$line" ] && continue
-#         left=$(printf '%s' "$line" | cut -c-"$column" | sed -E -e 's/[^ \ta-zA-Z0-9,._+@%/-]/\\&/g')
-#         if _is_enabled "$tmux_conf_copy_to_os_clipboard"; then
-#           right=$(printf '%s' "$line" | cut -c"$column"- | awk -F'\"' 'BEGIN { OFS = FS } { for (i = 1; i <= NF; i+=2) { gsub(/#{.+}/, "\"&\"", $i) } print }' | sed -E -e "s/copy-selection(-and-cancel)?$/copy-pipe\1 \"$command\"/g")
-#         else
-#           right=$(printf '%s' "$line" | cut -c"$column"- | awk -F'\"' 'BEGIN { OFS = FS } { for (i = 1; i <= NF; i+=2) { gsub(/#{.+}/, "\"&\"", $i) } print }' | sed -E -e "s/copy-pipe(-and-cancel)? \"$command\"$/copy-selection\1/g")
-#         fi
-#         eval "tmux $left $right" 2>/dev/null || true
-#       done  << EOF
-# $(tmux list-keys $table 2>/dev/null | grep -e 'copy-selection\|copy-pipe')
+#       left=$(printf '%s' "$line" | cut -c-"$column" | sed -E -e 's/[^ \ta-zA-Z0-9,._+@%/-]/\\&/g')
+#       if _is_enabled "$tmux_conf_copy_to_os_clipboard"; then
+#         right=$(printf '%s' "$line" | cut -c"$column"- | awk -F'\"' 'BEGIN { OFS = FS } { for (i = 1; i <= NF; i+=2) { gsub(/#{.+}/, "\"&\"", $i) } print }' | sed -E -e 's/;/\\\\\\\;/g' -e 's/-selection(-and-cancel)?$/-selection\1 \\\\\\\; run-shell "cut -c3- ~\/\.tmux\.conf | sh -s _copy #{pane_tty}"/g')
+#       else
+#         right=$(printf '%s' "$line" | cut -c"$column"- | awk -F'\"' 'BEGIN { OFS = FS } { for (i = 1; i <= NF; i+=2) { gsub(/#{.+}/, "\"&\"", $i) } print }' | sed -E -e 's/\\"/"/g' -e 's/run-shell "cut -c3- ~\/\.tmux\.conf \| sh -s _copy #\{pane_tty\}"//g' -e 's/#\{.+\}/\"&\"/g')
+#       fi
+#       eval "tmux $left $right" 2>/dev/null || true
+#     done  << EOF
+# $(tmux list-keys $table 2>/dev/null | grep -e 'copy-selection\|append-selection')
 # EOF
-#     done
-#  fi
+#   done
 # }
 #
 # _apply_theme() {

--- a/.tmux.conf
+++ b/.tmux.conf
@@ -623,8 +623,6 @@ run 'cut -c3- ~/.tmux.conf | sh -s _apply_configuration'
 # }
 #
 # _copy() {
-#   exec 2> /tmp/log.txt
-#   set -x
 #   tty="$SSH_TTY"
 #   tty=${tty:-$1}
 #   tty=${tty:-$(tmux display -p '#{pane_tty}')}
@@ -647,7 +645,6 @@ run 'cut -c3- ~/.tmux.conf | sh -s _apply_configuration'
 #   fi
 #
 #   printf '\033Ptmux;\033\033]52;c;%s\a\033\\' "$(printf %s "$buffer" | head -c 74994 | base64)" > "$tty"
-#   set +x
 # }
 #
 # _apply_overrides() {

--- a/.tmux.conf
+++ b/.tmux.conf
@@ -644,7 +644,7 @@ run 'cut -c3- ~/.tmux.conf | sh -s _apply_configuration'
 #     fi
 #   fi
 #
-#   printf '\033Ptmux;\033\033]52;c;%s\a\033\\' "$(printf %s "$buffer" | head -c 74994 | base64)" > "$tty"
+#   printf '\033Ptmux;\033\033]52;c;%s\a\033\\' "$(printf %s "$buffer" | head -c 74994 | base64 | tr -d '\n')" > "$tty"
 # }
 #
 # _apply_overrides() {

--- a/.tmux.conf.local
+++ b/.tmux.conf.local
@@ -265,7 +265,14 @@ tmux_conf_theme_clock_style='24'
 #   - true
 #   - false (default)
 # on macOS, this requires installing reattach-to-user-namespace, see README.md
-# on Linux, this requires xsel or xclip
+# on operating systems running X.org, this requires installing xsel or xclip
+# on Windows, clip.exe is used
+# on Cygwin, /dev/clipboard is used
+#
+# when connecting to a remote tmux session through SSH, copied text will be sent
+# back to the local clipboard (tmux >= 2.4) using the OSC 52 escape sequence
+#   - this requires set-clipboard to be set to on or external (default)
+#   - this requires having a terminal that understand the OSC 52 escape sequence
 tmux_conf_copy_to_os_clipboard=false
 
 

--- a/README.md
+++ b/README.md
@@ -92,7 +92,7 @@ Features
  - `C-a` acts as secondary prefix, while keeping default `C-b` prefix
  - visual theme inspired by [Powerline][]
  - [maximize any pane to a new window with `<prefix> +`][maximize-pane]
- - SSH aware username and hostname status line information
+ - SSH/Mosh aware username and hostname status line information
  - mouse mode toggle with `<prefix> m`
  - automatic usage of [`reattach-to-user-namespace`][reattach-to-user-namespace]
    if available
@@ -100,7 +100,7 @@ Features
  - uptime status line information
  - optional highlight of focused pane (tmux `>= 2.1`)
  - configurable new windows and panes behavior (optionally retain current path)
- - SSH aware split pane (reconnects to remote server, experimental)
+ - SSH/Mosh aware split pane (reconnects to remote server)
  - copy to OS clipboard (needs [`reattach-to-user-namespace`][reattach-to-user-namespace]
    on macOS, `xsel` or `xclip` on Linux)
  - [Facebook PathPicker][] integration if available
@@ -246,9 +246,9 @@ This configuration supports the following builtin variables:
  - `#{battery_status}`: is battery charging or discharging?
  - `#{battery_vbar}`: vertical battery charge bar
  - `#{circled_session_name}`: circled session number, up to 20
- - `#{hostname}`: SSH aware hostname information
- - `#{hostname_ssh}`: SSH aware hostname information, blank when no SSH
-   connection detected
+ - `#{hostname}`: SSH/Mosh aware hostname information
+ - `#{hostname_ssh}`: SSH/Mosh aware hostname information, blank when not
+   connected to a remote server through SSH/Mosh
  - `#{loadavg}`: load average
  - `#{pairing}`: is session attached to more than one client?
  - `#{prefix}`: is prefix being depressed?
@@ -258,9 +258,9 @@ This configuration supports the following builtin variables:
  - `#{uptime_h}`: uptime hours
  - `#{uptime_m}`: uptime minutes
  - `#{uptime_s}`: uptime seconds
- - `#{username}`: SSH aware username information
- - `#{username_ssh}`: SSH aware username information, blank when no SSH
-   connection detected
+ - `#{username}`: SSH/Mosh aware username information
+ - `#{username_ssh}`: SSH aware username information, blank when not connected
+   to a remote server through SSH/Mosh
 
 ### Accessing the macOS clipboard from within tmux sessions
 


### PR DESCRIPTION
[coreutils base64](https://www.gnu.org/software/coreutils/manual/html_node/base64-invocation.html#base64-invocation) wraps the output to 76 characters so only the first line of the base64'd content gets parsed (at least by iterm2). 
This commit removes the wrapping to prevent that.