### PR TITLE
Add support for TPM

### DIFF
--- a/.tmux.conf.local
+++ b/.tmux.conf.local
@@ -292,3 +292,18 @@ tmux_conf_copy_to_os_clipboard=false
 
 # move status line to top
 #set -g status-position top
+
+
+# -- plugins -------------------------------------------------------------------
+
+# List of plugins
+#set -g @plugin 'tmux-plugins/tpm'
+#set -g @plugin 'tmux-plugins/tmux-sensible'
+
+# Other examples:
+# set -g @plugin 'github_username/plugin_name'
+# set -g @plugin 'git@github.com/user/plugin'
+# set -g @plugin 'git@bitbucket.com/user/plugin'
+
+# Initialize TMUX plugin manager (keep this line at the very bottom of tmux.conf)
+#run -b '~/.tmux/plugins/tpm/tpm'

--- a/plugins/README.md
+++ b/plugins/README.md
@@ -1,0 +1,7 @@
+# Tmux Plugin Directory
+
+Clone here the TPM repo to enable it.
+
+```bash
+$ git clone https://github.com/tmux-plugins/tpm ~/.tmux/plugins/tpm
+```


### PR DESCRIPTION
I added support for TPM so that users can easily install plugins.
https://github.com/tmux-plugins/tpm

# Installation

1. Clone the TPM repo in the .tmux/plugins directory
```bash
$ git clone https://github.com/tmux-plugins/tpm ~/.tmux/plugins/tpm
```
2. Uncomment the lines in the plugins section of .tmux.conf.local according to the instructions from tpm

```bash
# List of plugins
set -g @plugin 'tmux-plugins/tpm'
set -g @plugin 'tmux-plugins/tmux-sensible'

# Other examples:
# set -g @plugin 'github_username/plugin_name'
# set -g @plugin 'git@github.com/user/plugin'
# set -g @plugin 'git@bitbucket.com/user/plugin'

# Initialize TMUX plugin manager (keep this line at the very bottom of tmux.conf)
run -b '~/.tmux/plugins/tpm/tpm'
```