### PR TITLE
Add tmux set-option to use xterm-256color version of true color

### DIFF
--- a/.tmux.conf
+++ b/.tmux.conf
@@ -10,6 +10,7 @@
 # -- general -------------------------------------------------------------------
 
 set -g default-terminal "screen-256color" # colors!
+set-option -ga terminal-overrides ",xterm-256color:Tc"
 setw -g xterm-keys on
 set -s escape-time 10                     # faster command sequences
 set -sg repeat-time 600                   # increase repeat timeout


### PR DESCRIPTION
This option is used to enable tmux to use `xterm-256color` version of true color.
Tmux's version of true color has some glitch that make vim's background display wrongly.

Device: mac OSX Mojave (10.14.2)
vimrc:
```viml
colorscheme nord "my colorscheme
set termguicolors
```

[N]vim background before set-option:
<img width="1440" alt="image" src="https://user-images.githubusercontent.com/43179681/52771302-2a8b1200-3068-11e9-8aa2-a5ca6e50a315.png">

[N]vim background after set-option:
<img width="1440" alt="image" src="https://user-images.githubusercontent.com/43179681/52771381-5c9c7400-3068-11e9-9d93-794aa64ff61d.png">