### PR TITLE
abstract colors as variables to be interpolated, disambiguate blues

### DIFF
--- a/.tmux.conf.local
+++ b/.tmux.conf.local
@@ -39,6 +39,23 @@ tmux_conf_new_session_prompt=false
 
 # -- display -------------------------------------------------------------------
 
+# color palette
+# reference as "${color_name}"
+# N.B., double quotes are necessary for interpolation
+#       single quotes mean string literal
+blue='#0087d7'
+light_blue='#00afff'
+gray='#444444'
+black='#000000'
+yellow='#ffff00'
+light_gray='#8a8a8a'
+dark_gray='#080808'
+red='#d70000'
+green='#5fff00'
+orange='#ff5f00'
+pink='#ff00af'
+white='#e4e4e4'
+
 # RGB 24-bit colour support (tmux >= 2.2), possible values are:
 #  - true
 #  - false (default)
@@ -55,7 +72,7 @@ tmux_conf_theme_highlight_focused_pane=false
 
 # focused pane colours:
 tmux_conf_theme_focused_pane_fg='default'
-tmux_conf_theme_focused_pane_bg='#0087d7'               # light blue
+tmux_conf_theme_focused_pane_bg="${blue}"
 
 # pane border style, possible values are:
 #   - thin (default)
@@ -63,31 +80,31 @@ tmux_conf_theme_focused_pane_bg='#0087d7'               # light blue
 tmux_conf_theme_pane_border_style=thin
 
 # pane borders colours:
-tmux_conf_theme_pane_border='#444444'                   # gray
-tmux_conf_theme_pane_active_border='#00afff'            # light blue
+tmux_conf_theme_pane_border="${gray}"
+tmux_conf_theme_pane_active_border="${light_blue}"
 
 # pane indicator colours
-tmux_conf_theme_pane_indicator='#00afff'                # light blue
-tmux_conf_theme_pane_active_indicator='#00afff'         # light blue
+tmux_conf_theme_pane_indicator="${light_blue}"
+tmux_conf_theme_pane_active_indicator="${light_blue}"
 
 # status line style
-tmux_conf_theme_message_fg='#000000'                    # black
-tmux_conf_theme_message_bg='#ffff00'                    # yellow
+tmux_conf_theme_message_fg="${black}"
+tmux_conf_theme_message_bg="${yellow}"
 tmux_conf_theme_message_attr='bold'
 
 # status line command style (<prefix> : Escape)
-tmux_conf_theme_message_command_fg='#ffff00'            # yellow
-tmux_conf_theme_message_command_bg='#000000'            # black
+tmux_conf_theme_message_command_fg="${yellow}"
+tmux_conf_theme_message_command_bg="${black}"
 tmux_conf_theme_message_command_attr='bold'
 
 # window modes style
-tmux_conf_theme_mode_fg='#000000'                       # black
-tmux_conf_theme_mode_bg='#ffff00'                       # yellow
+tmux_conf_theme_mode_fg="${black}"
+tmux_conf_theme_mode_bg="${yellow}"
 tmux_conf_theme_mode_attr='bold'
 
 # status line style
-tmux_conf_theme_status_fg='#8a8a8a'                     # light gray
-tmux_conf_theme_status_bg='#080808'                     # dark gray
+tmux_conf_theme_status_fg="${light_gray}"
+tmux_conf_theme_status_bg="${dark_gray}"
 tmux_conf_theme_status_attr='none'
 
 # terminal title
@@ -108,8 +125,8 @@ tmux_conf_theme_terminal_title='#h ❐ #S ● #I #W'
 #     - #{hostname_ssh}
 #     - #{username}
 #     - #{username_ssh}
-tmux_conf_theme_window_status_fg='#8a8a8a'              # light gray
-tmux_conf_theme_window_status_bg='#080808'              # dark gray
+tmux_conf_theme_window_status_fg="${light_gray}"
+tmux_conf_theme_window_status_bg="${dark_gray}"
 tmux_conf_theme_window_status_attr='none'
 tmux_conf_theme_window_status_format='#I #W'
 #tmux_conf_theme_window_status_format='#{circled_window_index} #W'
@@ -123,8 +140,8 @@ tmux_conf_theme_window_status_format='#I #W'
 #     - #{hostname_ssh}
 #     - #{username}
 #     - #{username_ssh}
-tmux_conf_theme_window_status_current_fg='#000000'      # black
-tmux_conf_theme_window_status_current_bg='#00afff'      # light blue
+tmux_conf_theme_window_status_current_fg="${black}"
+tmux_conf_theme_window_status_current_bg="${light_blue}"
 tmux_conf_theme_window_status_current_attr='bold'
 tmux_conf_theme_window_status_current_format='#I #W'
 #tmux_conf_theme_window_status_current_format='#{circled_window_index} #W'
@@ -136,12 +153,12 @@ tmux_conf_theme_window_status_activity_bg='default'
 tmux_conf_theme_window_status_activity_attr='underscore'
 
 # window bell status style
-tmux_conf_theme_window_status_bell_fg='#ffff00'         # yellow
+tmux_conf_theme_window_status_bell_fg="${yellow}"
 tmux_conf_theme_window_status_bell_bg='default'
 tmux_conf_theme_window_status_bell_attr='blink,bold'
 
 # window last status style
-tmux_conf_theme_window_status_last_fg='#00afff'         # light blue
+tmux_conf_theme_window_status_last_fg="${light_blue}"
 tmux_conf_theme_window_status_last_bg='default'
 tmux_conf_theme_window_status_last_attr='none'
 
@@ -182,13 +199,14 @@ tmux_conf_theme_status_left=' ❐ #S | ↑#{?uptime_d, #{uptime_d}d,}#{?uptime_h
 tmux_conf_theme_status_right='#{prefix}#{pairing}#{synchronized} #{?battery_status, #{battery_status},}#{?battery_bar, #{battery_bar},}#{?battery_percentage, #{battery_percentage},} , %R , %d %b | #{username}#{root} | #{hostname} '
 
 # status left style
-tmux_conf_theme_status_left_fg='#000000,#e4e4e4,#e4e4e4'  # black, white , white
-tmux_conf_theme_status_left_bg='#ffff00,#ff00af,#00afff'  # yellow, pink, white blue
+
+tmux_conf_theme_status_left_fg="${black},${white},${white}"
+tmux_conf_theme_status_left_bg="${yellow},${pink},${white}"
 tmux_conf_theme_status_left_attr='bold,none,none'
 
 # status right style
-tmux_conf_theme_status_right_fg='#8a8a8a,#e4e4e4,#000000' # light gray, white, black
-tmux_conf_theme_status_right_bg='#080808,#d70000,#e4e4e4' # dark gray, red, white
+tmux_conf_theme_status_right_fg="${light_gray},${white},${black}"
+tmux_conf_theme_status_right_bg="${dark_gray},${red},${white}"
 tmux_conf_theme_status_right_attr='none,none,bold'
 
 # pairing indicator
@@ -231,21 +249,22 @@ tmux_conf_battery_bar_length='auto'
 #   - heat
 #   - 'colour_full_fg,colour_empty_fg,colour_bg'
 tmux_conf_battery_bar_palette='gradient'
-#tmux_conf_battery_bar_palette='#d70000,#e4e4e4,#000000'   # red, white, black
+#tmux_conf_battery_bar_palette="${red},${white},${black}"
 
 # battery hbar palette, possible values are:
 #   - gradient (default)
 #   - heat
 #   - 'colour_low,colour_half,colour_full'
 tmux_conf_battery_hbar_palette='gradient'
-#tmux_conf_battery_hbar_palette='#d70000,#ff5f00,#5fff00'  # red, orange, green
+#tmux_conf_battery_hbar_palette="${red},${orange},${green}"
 
 # battery vbar palette, possible values are:
 #   - gradient (default)
 #   - heat
 #   - 'colour_low,colour_half,colour_full'
 tmux_conf_battery_vbar_palette='gradient'
-#tmux_conf_battery_vbar_palette='#d70000,#ff5f00,#5fff00'  # red, orange, green
+
+#tmux_conf_battery_vbar_palette="${red},${orange},${green}"
 
 # symbols used to indicate whether battery is charging or discharging
 tmux_conf_battery_status_charging='↑'       # U+2191
@@ -255,7 +274,7 @@ tmux_conf_battery_status_discharging='↓'    # U+2193
 #tmux_conf_battery_status_discharging='🔋 ' # U+1F50B
 
 # clock style
-tmux_conf_theme_clock_colour='#00afff'  # light blue
+tmux_conf_theme_clock_colour="${light_blue}"
 tmux_conf_theme_clock_style='24'
 
 

--- a/.tmux.conf.local
+++ b/.tmux.conf.local
@@ -199,7 +199,6 @@ tmux_conf_theme_status_left=' ❐ #S | ↑#{?uptime_d, #{uptime_d}d,}#{?uptime_h
 tmux_conf_theme_status_right='#{prefix}#{pairing}#{synchronized} #{?battery_status, #{battery_status},}#{?battery_bar, #{battery_bar},}#{?battery_percentage, #{battery_percentage},} , %R , %d %b | #{username}#{root} | #{hostname} '
 
 # status left style
-
 tmux_conf_theme_status_left_fg="${black},${white},${white}"
 tmux_conf_theme_status_left_bg="${yellow},${pink},${white}"
 tmux_conf_theme_status_left_attr='bold,none,none'
@@ -263,7 +262,6 @@ tmux_conf_battery_hbar_palette='gradient'
 #   - heat
 #   - 'colour_low,colour_half,colour_full'
 tmux_conf_battery_vbar_palette='gradient'
-
 #tmux_conf_battery_vbar_palette="${red},${orange},${green}"
 
 # symbols used to indicate whether battery is charging or discharging


### PR DESCRIPTION
Rad TMUX experience, thanks for crafting and sharing!

When I was configuring it to use the molokai color palette to mesh with my vim and iTerm, I found it useful to abstract the hex values for the colors into variables.

Here's a branch with those changes, submitted for your perusal.