### PR TITLE
FreeBSD support

### DIFF
--- a/.tmux.conf
+++ b/.tmux.conf
@@ -633,7 +633,7 @@ run -b '[ -z "#{session_id}" ] && [ -z "#{version}" ] && tmux set display-time 3
 #
 # _loadavg() {
 #   case $(uname -s) in
-#     *Darwin*)
+#     *Darwin*|*FreeBSD*)
 #       tmux set -g @loadavg "$(sysctl -q -n vm.loadavg | cut -d' ' -f2)"
 #       ;;
 #     *Linux*)

--- a/.tmux.conf
+++ b/.tmux.conf
@@ -599,7 +599,7 @@ run -b '[ -z "#{session_id}" ] && [ -z "#{version}" ] && tmux set display-time 3
 #
 # _uptime() {
 #   case $(uname -s) in
-#     *Darwin*)
+#     *Darwin*|*FreeBSD*)
 #       boot=$(sysctl -q -n kern.boottime | awk -F'[ ,:]+' '{ print $4 }')
 #       now=$(date +%s)
 #       ;;


### PR DESCRIPTION
As written above. The method of obtaining uptime is the same in FreeBSD as in Darwin, so this is a easy fix to show uptime in FreeBSD.