### PR TITLE
Add `#{custom}` builtin variable, run on a schedule

### DIFF
--- a/.tmux.conf
+++ b/.tmux.conf
@@ -645,6 +645,14 @@ run -b '[ -z "#{session_id}" ] && [ -z "#{version}" ] && tmux set display-time 3
 #   esac
 # }
 #
+# # update custom message on its own schedule
+# _custom() {
+#   if [ $(date +%s) -ge $(($tmux_custom_updated + 60 * ${tmux_custom_interval:-0})) ]; then
+#     tmux set -g @custom "$(eval $tmux_custom_command)"
+#     tmux setenv -g tmux_custom_updated $(date +%s)
+#   fi
+# }
+#
 # _split_window() {
 #   tty=${1:-$(tmux display -p '#{pane_tty}')}
 #   shift
@@ -1175,6 +1183,16 @@ run -b '[ -z "#{session_id}" ] && [ -z "#{version}" ] && tmux set display-time 3
 #       status_right=$(echo "$status_right" | sed -E \
 #         -e 's/#\{(\?)?loadavg/#\{\1@loadavg/g')
 #       status_right="#(cut -c3- ~/.tmux.conf | sh -s _loadavg)$status_right"
+#       ;;
+#   esac
+#
+#   case "$status_left $status_right" in
+#     *'#{custom}'*)
+#       status_left=$(echo "$status_left" | sed -E \
+#         -e 's/#\{(\?)?custom/#\{\1@custom/g')
+#       status_right=$(echo "$status_right" | sed -E \
+#         -e 's/#\{(\?)?custom/#\{\1@custom/g')
+#       status_right="#(cut -c3- ~/.tmux.conf | sh -s _custom)$status_right"
 #       ;;
 #   esac
 #

--- a/.tmux.conf.local
+++ b/.tmux.conf.local
@@ -260,6 +260,10 @@ tmux_conf_battery_status_discharging='↓'    # U+2193
 tmux_conf_theme_clock_colour='#00afff'  # light blue
 tmux_conf_theme_clock_style='24'
 
+# Custom message configuration.  Enter a command and interval here, and include
+# "#{custom}" in tmux_conf_theme_status_left or tmux_conf_theme_status_right
+tmux_custom_command='curl wttr.in/?format=3 2>/dev/null || echo "<weather unavailable>"'
+tmux_custom_interval=15 # number of minutes between updates
 
 # -- clipboard -----------------------------------------------------------------
 

--- a/README.md
+++ b/README.md
@@ -245,6 +245,8 @@ This configuration supports the following builtin variables:
  - `#{battery_status}`: is battery charging or discharging?
  - `#{battery_vbar}`: vertical battery charge bar
  - `#{circled_session_name}`: circled session number, up to 20
+ - `#{custom}`: custom command, specified in `tmux_custom_command`, and
+   executed once every `tmux_custom_interval` minutes
  - `#{hostname}`: SSH/Mosh aware hostname information
  - `#{hostname_ssh}`: SSH/Mosh aware hostname information, blank when not
    connected to a remote server through SSH/Mosh


### PR DESCRIPTION
After adding `#(curl wttr.in?format=3)` to my status line, I got a nasty-gram
from my IT department because my laptop was making "an abnormally large
volume of DNS requests".  I see that `status-interval` is set to 10 seconds,
so I was checking the weather ~3000 times on an average work day. That did
seem a bit excessive....

To keep from triggering the Darktrace alerts, as well as not DOS attack
wttr.in, I added provisions for a `#{custom}` command, which is only run if
the specified interval of time has passed.

The command and interval are controlled by variables in ~/.tmux.conf.local.
I configured it such that including `#{custom}` in the status line will
update the weather from wttr.in every 15 minutes.

Now I only check the weather ~35 times per day and my IT dept is back on
speaking terms with me.