### PR TITLE
added PREFIX z binding for kill-session command

### DIFF
--- a/.tmux.conf
+++ b/.tmux.conf
@@ -58,6 +58,9 @@ set -g visual-activity off
 # create session
 bind C-c new-session
 
+# kill current session
+bind z kill-session
+
 # find session
 bind C-f command-prompt -p find-session 'switch-client -t %%'
 


### PR DESCRIPTION
Please, review that PR, I added keybinding for kill-session command(PREFIX z). Maybe that could be useful for some folks. I think it's not that easy to accidentally press the key combination, so from that perspective there should not be any issues in usage.