### PR TITLE
added support for termux-battery-status

### DIFF
--- a/.tmux.conf
+++ b/.tmux.conf
@@ -270,26 +270,35 @@ run -b '[ -z "#{window_active}" ] && [ -z "#{version}" ] && tmux set display-tim
 # EOF
 #       ;;
 #     *Linux*)
-#       while IFS= read -r batpath; do
-#         grep -i -q device "$batpath/scope" 2> /dev/null && continue
-#
+#       if type "termux-battery-status" >/dev/null 2>&1; then
 #         if [ x"$discharging" != x"true" ]; then
-#           discharging=$(grep -qi "discharging" "$batpath/status" && echo "true" || echo "false")
+#           discharging=$(termux-battery-status | jq -r '.status' | grep -qi "DISCHARGING" && echo "true" || echo "false")
 #         fi
-#         bat_capacity="$batpath/capacity"
-#         if [ -r "$bat_capacity" ]; then
-#           charge=$(awk -v charge="$charge" -v capacity="$(cat "$bat_capacity")" 'BEGIN { print charge + capacity / 100 }')
-#         else
-#           bat_energy_full="$batpath/energy_full"
-#           bat_energy_now="$batpath/energy_now"
-#           if [ -r "$bat_energy_full" ] && [ -r "$bat_energy_now" ]; then
-#             charge=$(awk -v charge="$charge" -v energy_now="$(cat "$bat_energy_now")" -v energy_full="$(cat "$bat_energy_full")" 'BEGIN { print charge + energy_now / energy_full }')
-#           fi
-#         fi
+#         percentage=$(termux-battery-status | jq -r '.percentage')
+#         charge=$(awk -v charge="$charge" -v percentage="${percentage%%%}" 'BEGIN { print charge + percentage / 100 }')
 #         count=$((count + 1))
-#       done  << EOF
+#       else
+#         while IFS= read -r batpath; do
+#           grep -i -q device "$batpath/scope" 2> /dev/null && continue
+#
+#           if [ x"$discharging" != x"true" ]; then
+#             discharging=$(grep -qi "discharging" "$batpath/status" && echo "true" || echo "false")
+#           fi
+#           bat_capacity="$batpath/capacity"
+#           if [ -r "$bat_capacity" ]; then
+#             charge=$(awk -v charge="$charge" -v capacity="$(cat "$bat_capacity")" 'BEGIN { print charge + capacity / 100 }')
+#           else
+#             bat_energy_full="$batpath/energy_full"
+#             bat_energy_now="$batpath/energy_now"
+#             if [ -r "$bat_energy_full" ] && [ -r "$bat_energy_now" ]; then
+#               charge=$(awk -v charge="$charge" -v energy_now="$(cat "$bat_energy_now")" -v energy_full="$(cat "$bat_energy_full")" 'BEGIN { print charge + energy_now / energy_full }')
+#             fi
+#           fi
+#           count=$((count + 1))
+#         done  << EOF
 # $(find /sys/class/power_supply -maxdepth 1 -iname '*bat*')
 # EOF
+#       fi
 #       ;;
 #     *CYGWIN*|*MSYS*|*MINGW*)
 #       while IFS= read -r line; do


### PR DESCRIPTION
Hi,
first thank you for that great project. I added an if condition and in case the command `termux-battery-status` exists (termux emulator) then it will use that command to pull the battery information.

If `termux-battery-status` command does **not** exist, then will run the same code than would have ran before this pull request. In oder words, that block of code hasn't been modified, just moved down few lines.

Both cases have been tested.

Regards,