### PR TITLE
Added icon for mouse mode

### DIFF
--- a/.tmux.conf
+++ b/.tmux.conf
@@ -278,8 +278,7 @@ run -b '[ -z "#{window_active}" ] && [ -z "#{version}" ] && tmux set display-tim
 #     new="on"
 #   fi
 #
-#   tmux set -g mouse $new \;\
-#        display "mouse: $new"
+#   tmux set -g mouse $new
 # }
 #
 # _battery_info() {
@@ -981,6 +980,11 @@ run -b '[ -z "#{window_active}" ] && [ -z "#{version}" ] && tmux set display-tim
 #   tmux_conf_theme_prefix_bg=${tmux_conf_theme_prefix_bg:-none}
 #   tmux_conf_theme_prefix_attr=${tmux_conf_theme_prefix_attr:-none}
 #
+#   tmux_conf_theme_mouse=${tmux_conf_theme_mouse:-↗}                            # U+2197
+#   tmux_conf_theme_mouse_fg=${tmux_conf_theme_mouse_fg:-none}
+#   tmux_conf_theme_mouse_bg=${tmux_conf_theme_mouse_bg:-none}
+#   tmux_conf_theme_mouse_attr=${tmux_conf_theme_mouse_attr:-none}
+#
 #   tmux_conf_theme_root=${tmux_conf_theme_root:-!}
 #   tmux_conf_theme_root_fg=${tmux_conf_theme_root_fg:-none}
 #   tmux_conf_theme_root_bg=${tmux_conf_theme_root_bg:-none}
@@ -1002,6 +1006,7 @@ run -b '[ -z "#{window_active}" ] && [ -z "#{version}" ] && tmux set display-tim
 #     status_left=$(echo "$tmux_conf_theme_status_left" | sed \
 #       -e "s/#{pairing}/#[fg=$tmux_conf_theme_pairing_fg]#[bg=$tmux_conf_theme_pairing_bg]#[$tmux_conf_theme_pairing_attr]#{?session_many_attached,$tmux_conf_theme_pairing ,}/g" \
 #       -e "s/#{prefix}/#[fg=$tmux_conf_theme_prefix_fg]#[bg=$tmux_conf_theme_prefix_bg]#[$tmux_conf_theme_prefix_attr]#{?client_prefix$tmux_conf_theme_prefix ,$(print "$tmux_conf_theme_prefix" | sed -e 's/./ /g') }/g" \
+#       -e "s/#{mouse}/#[fg=$tmux_conf_theme_mouse_fg]#[bg=$tmux_conf_theme_mouse_bg]#[$tmux_conf_theme_mouse_attr]#{?mouse,$tmux_conf_theme_mouse ,$(print "$tmux_conf_theme_mouse" | sed -e 's/./ /g') }/g" \
 #       -e "s%#{synchronized}%#[fg=$tmux_conf_theme_synchronized_fg]#[bg=$tmux_conf_theme_synchronized_bg]#[$tmux_conf_theme_synchronized_attr]#{?pane_synchronized,$tmux_conf_theme_synchronized ,}%g" \
 #       -e 's%#{circled_session_name}%#(cut -c3- ~/.tmux.conf | sh -s _circled #S)%g')
 #
@@ -1080,7 +1085,7 @@ run -b '[ -z "#{window_active}" ] && [ -z "#{version}" ] && tmux set display-tim
 #
 #   # -- status-right style
 #
-#   tmux_conf_theme_status_right=${tmux_conf_theme_status_right-' #{prefix}#{pairing}#{synchronized}#{?battery_status, #{battery_status},}#{?battery_bar, #{battery_bar},}#{?battery_percentage, #{battery_percentage},} , %R , %d %b | #{username}#{root} | #{hostname} '}
+#   tmux_conf_theme_status_right=${tmux_conf_theme_status_right-' #{prefix}#{mouse}#{pairing}#{synchronized}#{?battery_status, #{battery_status},}#{?battery_bar, #{battery_bar},}#{?battery_percentage, #{battery_percentage},} , %R , %d %b | #{username}#{root} | #{hostname} '}
 #   tmux_conf_theme_status_right_fg=${tmux_conf_theme_status_right_fg:-$tmux_conf_theme_colour_12,$tmux_conf_theme_colour_13,$tmux_conf_theme_colour_14}
 #   tmux_conf_theme_status_right_bg=${tmux_conf_theme_status_right_bg:-$tmux_conf_theme_colour_15,$tmux_conf_theme_colour_16,$tmux_conf_theme_colour_17}
 #   tmux_conf_theme_status_right_attr=${tmux_conf_theme_status_right_attr:-none,none,bold}
@@ -1089,6 +1094,7 @@ run -b '[ -z "#{window_active}" ] && [ -z "#{version}" ] && tmux set display-tim
 #     status_right=$(echo "$tmux_conf_theme_status_right" | sed \
 #       -e "s/#{pairing}/#[fg=$tmux_conf_theme_pairing_fg]#[bg=$tmux_conf_theme_pairing_bg]#[$tmux_conf_theme_pairing_attr]#{?session_many_attached,$tmux_conf_theme_pairing ,}/g" \
 #       -e "s/#{prefix}/#[fg=$tmux_conf_theme_prefix_fg]#[bg=$tmux_conf_theme_prefix_bg]#[$tmux_conf_theme_prefix_attr]#{?client_prefix,$tmux_conf_theme_prefix ,$(printf "$tmux_conf_theme_prefix" | sed -e 's/./ /g') }/g" \
+#       -e "s/#{mouse}/#[fg=$tmux_conf_theme_mouse_fg]#[bg=$tmux_conf_theme_mouse_bg]#[$tmux_conf_theme_mouse_attr]#{?mouse,$tmux_conf_theme_mouse ,$(printf "$tmux_conf_theme_mouse" | sed -e 's/./ /g') }/g" \
 #       -e "s%#{synchronized}%#[fg=$tmux_conf_theme_synchronized_fg]#[bg=$tmux_conf_theme_synchronized_bg]#[$tmux_conf_theme_synchronized_attr]#{?pane_synchronized,$tmux_conf_theme_synchronized ,}%g" \
 #       -e 's%#{circled_session_name}%#(cut -c3- ~/.tmux.conf | sh -s _circled #S)%g')
 #

--- a/.tmux.conf.local
+++ b/.tmux.conf.local
@@ -206,6 +206,7 @@ tmux_conf_theme_right_separator_sub="|"
 #     - #{hostname_ssh}
 #     - #{hostname}
 #     - #{loadavg}
+#     - #{mouse}
 #     - #{pairing}
 #     - #{prefix}
 #     - #{root}
@@ -218,7 +219,7 @@ tmux_conf_theme_right_separator_sub="|"
 #     - #{username}
 #     - #{username_ssh}
 tmux_conf_theme_status_left=" ❐ #S | ↑#{?uptime_y, #{uptime_y}y,}#{?uptime_d, #{uptime_d}d,}#{?uptime_h, #{uptime_h}h,}#{?uptime_m, #{uptime_m}m,} "
-tmux_conf_theme_status_right=" #{prefix}#{pairing}#{synchronized}#{?battery_status,#{battery_status},}#{?battery_bar, #{battery_bar},}#{?battery_percentage, #{battery_percentage},} , %R , %d %b | #{username}#{root} | #{hostname} "
+tmux_conf_theme_status_right=" #{prefix}#{mouse}#{pairing}#{synchronized}#{?battery_status,#{battery_status},}#{?battery_bar, #{battery_bar},}#{?battery_percentage, #{battery_percentage},} , %R , %d %b | #{username}#{root} | #{hostname} "
 
 # status left style
 tmux_conf_theme_status_left_fg="$tmux_conf_theme_colour_6,$tmux_conf_theme_colour_7,$tmux_conf_theme_colour_8"
@@ -241,6 +242,12 @@ tmux_conf_theme_prefix="⌨"                  # U+2328
 tmux_conf_theme_prefix_fg="none"
 tmux_conf_theme_prefix_bg="none"
 tmux_conf_theme_prefix_attr="none"
+
+# mouse indicator
+tmux_conf_theme_mouse="↗"                   # U+2197
+tmux_conf_theme_mouse_fg="none"
+tmux_conf_theme_mouse_bg="none"
+tmux_conf_theme_mouse_attr="none"
 
 # root indicator
 tmux_conf_theme_root="!"


### PR DESCRIPTION
Fixes #295 

mouse icon is to the left of the battery by default.

_toggle_mouse no longer prints a status message as the status icon
should give enough information.