### PR TITLE
Busybox `tr` compatibility

### DIFF
--- a/.tmux.conf
+++ b/.tmux.conf
@@ -189,7 +189,7 @@ run 'cut -c3- ~/.tmux.conf | sh -s _apply_configuration'
 #
 # _uname_s=$(uname -s)
 #
-# _tmux_version=$(tmux -V | tr -cd '[:digit:].' | cut -d' ' -f2 | awk -F '.' '{print $1 * 100 + $2}')
+# _tmux_version=$(tmux -V | tr -cd '0123456789.' | cut -d' ' -f2 | awk -F '.' '{print $1 * 100 + $2}')
 #
 # _is_enabled() {
 #   [ x"$1" = x"true" ] || [ x"$1" = x"yes" ] || [ x"$1" = x"enabled" ] || [ x"$1" = x"1" ]


### PR DESCRIPTION
Busybox `tr` doesn't support groups like `[:digit:]`. Using digits directly is not as clean but improves portability.