### PR TITLE
fix left status prefix rendering

### DIFF
--- a/.tmux.conf
+++ b/.tmux.conf
@@ -1023,7 +1023,7 @@ run 'cut -c3- ~/.tmux.conf | sh -s _apply_configuration'
 #   if [ -n "$tmux_conf_theme_status_left" ]; then
 #     status_left=$(echo "$tmux_conf_theme_status_left" | sed \
 #       -e "s/#{pairing}/#[fg=$tmux_conf_theme_pairing_fg]#[bg=$tmux_conf_theme_pairing_bg]#[$tmux_conf_theme_pairing_attr]#{?session_many_attached,$tmux_conf_theme_pairing ,}/g" \
-#       -e "s/#{prefix}/#[fg=$tmux_conf_theme_prefix_fg]#[bg=$tmux_conf_theme_prefix_bg]#[$tmux_conf_theme_prefix_attr]#{?client_prefix$tmux_conf_theme_prefix ,$(printf "$tmux_conf_theme_prefix" | sed -e 's/./ /g') }/g" \
+#       -e "s/#{prefix}/#[fg=$tmux_conf_theme_prefix_fg]#[bg=$tmux_conf_theme_prefix_bg]#[$tmux_conf_theme_prefix_attr]#{?client_prefix,$tmux_conf_theme_prefix ,$(printf "$tmux_conf_theme_prefix" | sed -e 's/./ /g') }/g" \
 #       -e "s/#{mouse}/#[fg=$tmux_conf_theme_mouse_fg]#[bg=$tmux_conf_theme_mouse_bg]#[$tmux_conf_theme_mouse_attr]#{?mouse,$tmux_conf_theme_mouse ,$(printf "$tmux_conf_theme_mouse" | sed -e 's/./ /g') }/g" \
 #       -e "s%#{synchronized}%#[fg=$tmux_conf_theme_synchronized_fg]#[bg=$tmux_conf_theme_synchronized_bg]#[$tmux_conf_theme_synchronized_attr]#{?pane_synchronized,$tmux_conf_theme_synchronized ,}%g" \
 #       -e 's%#{circled_session_name}%#(cut -c3- ~/.tmux.conf | sh -s _circled #S)%g')


### PR DESCRIPTION
A missing comma is preventing the prefix symbol from rendering in the left status bar. (compare this to the correct config string for the right status where it does render)