### PR TITLE
Remove $ from install cmds to allow for copy paste

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,10 +19,10 @@ To install, run the following from your terminal: (you may want to backup your
 existing `~/.tmux.conf` first)
 
 ```
-$ cd
-$ git clone https://github.com/gpakosz/.tmux.git
-$ ln -s -f .tmux/.tmux.conf
-$ cp .tmux/.tmux.conf.local .
+cd
+git clone https://github.com/gpakosz/.tmux.git
+ln -s -f .tmux/.tmux.conf
+cp .tmux/.tmux.conf.local .
 ```
 
 💡 You can clone the repository anywhere you want, provided you create the
@@ -30,9 +30,9 @@ proper `~/.tmux.conf` symlink and you copy the `.tmux.conf.local` sample file in
 your home directory:
 
 ```
-$ git clone https://github.com/gpakosz/.tmux.git /path/to/oh-my-tmux
-$ ln -s -f /path/to/oh-my-tmux/.tmux.conf ~/.tmux.conf
-$ cp /path/to/oh-my-tmux/.tmux.conf.local ~/.tmux.conf.local
+git clone https://github.com/gpakosz/.tmux.git /path/to/oh-my-tmux
+ln -s -f /path/to/oh-my-tmux/.tmux.conf ~/.tmux.conf
+cp /path/to/oh-my-tmux/.tmux.conf.local ~/.tmux.conf.local
 ```
 
 Then proceed to [customize] your `~/.tmux.conf.local` copy.


### PR DESCRIPTION
This is a pretty minor change. Feel free to close it if you don't agree with it but removing the `$` symbols would expedite installations for users (since you can just copy and paste and the shell runs each command in sequence). As it is now I always have to copy first to an editor, remove the first two columns, and then do a copy paste into a shell.

Cheers.