### PR TITLE
Make spacers more consistent when window status background is the same as the default theme

### DIFF
--- a/.tmux.conf
+++ b/.tmux.conf
@@ -918,10 +918,14 @@ run 'cut -c3- ~/.tmux.conf | sh -s _apply_configuration'
 #   tmux_conf_theme_window_status_last_bg=${tmux_conf_theme_window_status_last_bg:-default}
 #   tmux_conf_theme_window_status_last_attr=${tmux_conf_theme_window_status_last_attr:-none}
 #
-#   spacer=' '
-#   spacer_current=' '
+#   if [[ (x"$tmux_conf_theme_window_status_bg" = x"$tmux_conf_theme_status_bg" || x"$tmux_conf_theme_window_status_bg" = x"default") && (x"$tmux_conf_theme_window_status_current_fg" = x"$tmux_conf_theme_window_status_fg") ]]; then
+#     spacer=''
+#     spacer_current=' '
+#   else
+#     spacer=' '
+#     spacer_current=' '
+#   fi
 #   spacer_last=' '
-#
 #   if [ x"$tmux_conf_theme_window_status_activity_bg" = x"$tmux_conf_theme_status_bg" ] || [ x"$tmux_conf_theme_window_status_activity_bg" = x"default" ] ; then
 #     spacer_activity=''
 #     spacer_last_activity="$spacer_last"

--- a/.tmux.conf
+++ b/.tmux.conf
@@ -918,18 +918,10 @@ run 'cut -c3- ~/.tmux.conf | sh -s _apply_configuration'
 #   tmux_conf_theme_window_status_last_bg=${tmux_conf_theme_window_status_last_bg:-default}
 #   tmux_conf_theme_window_status_last_attr=${tmux_conf_theme_window_status_last_attr:-none}
 #
-#   if [ x"$tmux_conf_theme_window_status_bg" = x"$tmux_conf_theme_status_bg" ] || [ x"$tmux_conf_theme_window_status_bg" = x"default" ]; then
-#     spacer=''
-#     spacer_current=' '
-#   else
-#     spacer=' '
-#     spacer_current=' '
-#   fi
-#   if [ x"$tmux_conf_theme_window_status_last_bg" = x"$tmux_conf_theme_status_bg" ] || [ x"$tmux_conf_theme_window_status_last_bg" = x"default" ] ; then
-#     spacer_last=''
-#   else
-#     spacer_last=' '
-#   fi
+#   spacer=' '
+#   spacer_current=' '
+#   spacer_last=' '
+#
 #   if [ x"$tmux_conf_theme_window_status_activity_bg" = x"$tmux_conf_theme_status_bg" ] || [ x"$tmux_conf_theme_window_status_activity_bg" = x"default" ] ; then
 #     spacer_activity=''
 #     spacer_last_activity="$spacer_last"


### PR DESCRIPTION
Avoids unnecessary shifting of window tabs, for people who like to keep things simple and just use the foreground/attr/format to indicate current/last windows (much like the original tmux which only uses background colors and * icon but not tab-size).

I'm willing to discuss and improve this request further