### PR TITLE
Fixed an issue with local config rebinding the prefix key

### DIFF
--- a/.tmux.conf.local
+++ b/.tmux.conf.local
@@ -338,7 +338,7 @@ tmux_conf_copy_to_os_clipboard=false
 #set -g mode-keys vi
 
 # replace C-b by C-a instead of using both prefixes
-# set -gu prefix2
+# set -g -u prefix2
 # unbind C-a
 # unbind C-b
 # set -g prefix C-a


### PR DESCRIPTION
The default local config caused an issue with newer versions of tmux when using the rebind prefix example. The set command seems to have a problem with combining the flags in newer versions. Separating the flags fixed the issue. 