### PR TITLE
Update README with git clone depth limitation

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ existing `~/.tmux.conf` first)
 
 ```
 $ cd
-$ git clone https://github.com/gpakosz/.tmux.git
+$ git clone --depth 1 https://github.com/gpakosz/.tmux.git
 $ ln -s -f .tmux/.tmux.conf
 $ cp .tmux/.tmux.conf.local .
 ```


### PR DESCRIPTION
Limiting the git clone operation to only the most recent iteration keeps the user's local copy as small as possible.