### PR TITLE
pass #{pane_current_path} to _fpp() and then to split-window

### DIFF
--- a/.tmux.conf
+++ b/.tmux.conf
@@ -106,7 +106,7 @@ bind U run "cut -c3- ~/.tmux.conf | sh -s _urlview #{pane_id}"
 
 # -- facebook pathpicker -------------------------------------------------------
 
-bind F run "cut -c3- ~/.tmux.conf | sh -s _fpp #{pane_id}"
+bind F run "cut -c3- ~/.tmux.conf | sh -s _fpp #{pane_id} #{pane_current_path}"
 
 
 # -- list choice (tmux < 2.4) --------------------------------------------------
@@ -1485,7 +1485,7 @@ run 'cut -c3- ~/.tmux.conf | sh -s _apply_configuration'
 #
 # _fpp() {
 #   tmux capture-pane -J -S - -E - -b "fpp-$1" -t "$1"
-#   tmux split-window "tmux show-buffer -b fpp-$1 | fpp || true; tmux delete-buffer -b fpp-$1"
+#   tmux split-window -c $2 "tmux show-buffer -b fpp-$1 | fpp || true; tmux delete-buffer -b fpp-$1"
 # }
 #
 # "$@"


### PR DESCRIPTION
## Summary

Changes to assure fpp  will be executed in the current pane path.

## Issue

- fpp ignores matches that it could not find the actual file 
- binds with `run-shell` are executed on the place they are defined

So if we do something like

```bash
[ ~ ] $ cd projects/my_proj
[ ~/projects/.my_proj ] $ ls README.md
README.md
```
When we type `<prefix> F` fpp will check if the `README.md` file exists in the place where `tmux.conf` is, so it will not return the expected result.

## Fix

Pass the current panel path to `_fpp` function and use it when creating the split-pane