### PR TITLE
feat: add support for copying to Wayland clipboard

### DIFF
--- a/.tmux.conf
+++ b/.tmux.conf
@@ -150,6 +150,7 @@ run -b 'tmux bind -T copy-mode-vi L send -X end-of-line 2> /dev/null || true'
 # copy to X11 clipboard
 if -b 'command -v xsel > /dev/null 2>&1' 'bind y run -b "tmux save-buffer - | xsel -i -b"'
 if -b '! command -v xsel > /dev/null 2>&1 && command -v xclip > /dev/null 2>&1' 'bind y run -b "tmux save-buffer - | xclip -i -selection clipboard >/dev/null 2>&1"'
+if -b '! command -v xsel > /dev/null 2>&1 && ! command -v xclip > /dev/null 2>&1 && command -v wl-copy > /dev/null 2>&1' 'bind y run -b "tmux save-buffer - | wl-copy"'
 # copy to macOS clipboard
 if -b 'command -v pbcopy > /dev/null 2>&1' 'bind y run -b "tmux save-buffer - | pbcopy"'
 if -b 'command -v reattach-to-user-namespace > /dev/null 2>&1' 'bind y run -b "tmux save-buffer - | reattach-to-user-namespace pbcopy"'


### PR DESCRIPTION
Wayland is pretty common now, so it makes sense to have support for `wl-copy` here.