### PR TITLE
fix: remove mvim and gvim substitutions

### DIFF
--- a/.tmux.conf
+++ b/.tmux.conf
@@ -26,7 +26,7 @@ setw -q -g utf8 on
 set -g history-limit 5000                 # boost history
 
 # edit configuration
-bind e new-window -n "~/.tmux.conf.local" sh -c 'EDITOR=${EDITOR//mvim/vim} && EDITOR=${EDITOR//gvim/vim} && ${EDITOR:-vim} ~/.tmux.conf.local && tmux source ~/.tmux.conf && tmux display "~/.tmux.conf sourced"'
+bind e new-window -n "~/.tmux.conf.local" sh -c '${EDITOR:-vim} ~/.tmux.conf.local && tmux source ~/.tmux.conf && tmux display "~/.tmux.conf sourced"'
 
 # reload configuration
 bind r source-file ~/.tmux.conf \; display '~/.tmux.conf sourced'


### PR DESCRIPTION
Fixes #593