### PR TITLE
fix wrong comment when spliting window

### DIFF
--- a/.tmux.conf
+++ b/.tmux.conf
@@ -65,9 +65,9 @@ bind C-f command-prompt -p find-session 'switch-client -t %%'
 # session navigation
 bind BTab switch-client -l  # move to last session
 
-# split current window horizontally
-bind - split-window -v
 # split current window vertically
+bind - split-window -v
+# split current window horizontally
 bind _ split-window -h
 
 # pane navigation


### PR DESCRIPTION
opposite comment: vertically and horizontally