### PR TITLE
feat(tpm): load plugins even offiine

### DIFF
--- a/.tmux.conf
+++ b/.tmux.conf
@@ -1483,13 +1483,12 @@ run 'cut -c3- "$TMUX_CONF" | sh -s _apply_configuration'
 #     fi
 #   else
 #     if [ "$(command tmux display -p '#{pid} #{version} #{socket_path}')" = "$($TMUX_PROGRAM display -p '#{pid} #{version} #{socket_path}')" ]; then
-#       if git ls-remote -hq https://github.com/gpakosz/.tmux.git master > /dev/null; then
-#         tpm_plugins=$(cat << EOF | tr ' ' '\n' | awk '/^\s*$/ {next;}; !seen[$0]++ { gsub(/^[ \t]+/,"",$0); gsub(/[ \t]+$/,"",$0); print $0 }'
-#           $(awk '/^[ \t]*set(-option)?.*[ \t]@plugin[ \t]/ { gsub(/'\''/, ""); gsub(/'\"'/, ""); print $NF }' "$TMUX_CONF_LOCAL" 2>/dev/null)
+#       tpm_plugins=$(cat << EOF | tr ' ' '\n' | awk '/^\s*$/ {next;}; !seen[$0]++ { gsub(/^[ \t]+/,"",$0); gsub(/[ \t]+$/,"",$0); print $0 }'
+#         $(awk '/^[ \t]*set(-option)?.*[ \t]@plugin[ \t]/ { gsub(/'\''/, ""); gsub(/'\"'/, ""); print $NF }' "$TMUX_CONF_LOCAL" 2>/dev/null)
 # EOF
-#         )
-#         tmux set -g '@tpm_plugins' "$tpm_plugins"
-#
+#       )
+#       tmux set -g '@tpm_plugins' "$tpm_plugins"
+#       if git ls-remote -hq https://github.com/gpakosz/.tmux.git master > /dev/null; then
 #         if [ ! -d "$TMUX_PLUGIN_MANAGER_PATH/tpm" ]; then
 #           install_tpm=true
 #           tmux display 'Installing tpm and plugins...'


### PR DESCRIPTION
Currently, if the upstream repository is not reachable (e.g. no internet access), the variable `@tpm_plugins` is not populated. In that case, tpm loads no plugin.

I do not know whether this is intentional, but this was inconvenient for me whenever I am travelling, or when I start my tmux server before the wifi connection has been established.

The simple patch I propose populates `@tpm_plugins` regardless of access to the upstream repository.

This was only tested on my personal devices (tmux 3.3a). I have been using it for several days without issue.