### PR TITLE
vim editor syntax highlighting for .tmux.conf.local

### DIFF
--- a/.tmux.conf
+++ b/.tmux.conf
@@ -28,7 +28,7 @@ setw -q -g utf8 on
 set -g history-limit 5000                 # boost history
 
 # edit configuration
-bind e new-window -n "#{TMUX_CONF_LOCAL}" sh -c '${EDITOR:-vim} "$TMUX_CONF_LOCAL" && "$TMUX_PROGRAM" ${TMUX_SOCKET:+-S "$TMUX_SOCKET"} source "$TMUX_CONF" \; display "$TMUX_CONF_LOCAL sourced"'
+bind e new-window -n "#{TMUX_CONF_LOCAL}" sh -c '${EDITOR:-vim} -c ":set syntax=tmux" "$TMUX_CONF_LOCAL" && "$TMUX_PROGRAM" ${TMUX_SOCKET:+-S "$TMUX_SOCKET"} source "$TMUX_CONF" \; display "$TMUX_CONF_LOCAL sourced"'
 
 # reload configuration
 bind r run '"$TMUX_PROGRAM" ${TMUX_SOCKET:+-S "$TMUX_SOCKET"} source "$TMUX_CONF"' \; display "#{TMUX_CONF} sourced"


### PR DESCRIPTION
Possible solution to #667 for at least vim editors