### PR TITLE
New shortcut for splitting vertically the windows, bind |

### DIFF
--- a/.tmux.conf
+++ b/.tmux.conf
@@ -72,6 +72,7 @@ bind BTab switch-client -l  # move to last session
 bind - split-window -v
 # split current window vertically
 bind _ split-window -h
+bind | split-window -h
 
 # pane navigation
 bind -r h select-pane -L  # move left


### PR DESCRIPTION
In cli apps as Vim/Neovim is very common to have the pipe `|` as part of some shortcut to divide vertically the window.

In the same way that is very natural to split horizontally with `-`, doing so vertically with `|` feels natural.