### PR TITLE
Quit urlscan after opening/copying a single link

### DIFF
--- a/.tmux.conf
+++ b/.tmux.conf
@@ -1717,7 +1717,7 @@ run 'cut -c3- "$TMUX_CONF" | sh -s _apply_configuration'
 #   tmux capture-pane -J -S - -E - -b "urlview-$1" -t "$1"
 #   command='false'
 #   command -v urlview > /dev/null 2>&1 && command='urlview'
-#   command -v urlscan > /dev/null 2>&1 && command='urlscan --compact --dedupe'
+#   command -v urlscan > /dev/null 2>&1 && command='urlscan --compact --dedupe --single'
 #   tmux split-window "'$TMUX_PROGRAM' ${TMUX_SOCKET:+-S "$TMUX_SOCKET"} show-buffer -b 'urlview-$1' | $command || true; '$TMUX_PROGRAM' ${TMUX_SOCKET:+-S "$TMUX_SOCKET"} delete-buffer -b 'urlview-$1'"
 # }
 #


### PR DESCRIPTION
This will make this tool a little bit easier to use.

From help page:
```console
  --single, -s          Quit urlscan after opening/copying a single link.
```