### PR TITLE
Remove preceding dollar sign ($) from demo code

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,26 +23,26 @@ You can install Oh my tmux! at any of the following locations:
 
 Installing in `~`:
 ```
-$ cd
-$ git clone https://github.com/gpakosz/.tmux.git
-$ ln -s -f .tmux/.tmux.conf
-$ cp .tmux/.tmux.conf.local .
+cd
+git clone https://github.com/gpakosz/.tmux.git
+ln -s -f .tmux/.tmux.conf
+cp .tmux/.tmux.conf.local .
 ```
 
 Installing in `$XDG_CONFIG_HOME/tmux`:
 ```
-$ git clone https://github.com/gpakosz/.tmux.git "/path/to/oh-my-tmux"
-$ mkdir -p "$XDG_CONFIG_HOME/tmux"
-$ ln -s "/path/to/oh-my-tmux/.tmux.conf" "$XDG_CONFIG_HOME/tmux/tmux.conf"
-$ cp "/path/to/oh-my-tmux/.tmux.conf.local" "$XDG_CONFIG_HOME/tmux/tmux.conf.local"
+git clone https://github.com/gpakosz/.tmux.git "/path/to/oh-my-tmux"
+mkdir -p "$XDG_CONFIG_HOME/tmux"
+ln -s "/path/to/oh-my-tmux/.tmux.conf" "$XDG_CONFIG_HOME/tmux/tmux.conf"
+cp "/path/to/oh-my-tmux/.tmux.conf.local" "$XDG_CONFIG_HOME/tmux/tmux.conf.local"
 ```
 
 Installing in `~/.config/tmux`:
 ```
-$ git clone https://github.com/gpakosz/.tmux.git "/path/to/oh-my-tmux"
-$ mkdir -p "~/.config/tmux"
-$ ln -s "/path/to/oh-my-tmux/.tmux.conf" "~/.config/tmux/tmux.conf"
-$ cp "/path/to/oh-my-tmux/.tmux.conf.local" "~/.config/tmux/tmux.conf.local"
+git clone https://github.com/gpakosz/.tmux.git "/path/to/oh-my-tmux"
+mkdir -p "~/.config/tmux"
+ln -s "/path/to/oh-my-tmux/.tmux.conf" "~/.config/tmux/tmux.conf"
+cp "/path/to/oh-my-tmux/.tmux.conf.local" "~/.config/tmux/tmux.conf.local"
 ```
 ⚠️ When installing `$XDG_CONFIG_HOME/tmux` or `~/.config/tmux`, the configuration
 file names don't have a leading `.` character.


### PR DESCRIPTION
Remove preceding dollar sign from installation code snippet.

In most cases, people just want to copy the code snippet to install a program, drop it in their terminal, and be done with it. The preceding dollar sign can be a tiny but significant frustration.