### PR TITLE
replace BTab with 'l' for improved keybinding compatibility

### DIFF
--- a/.tmux.conf
+++ b/.tmux.conf
@@ -75,7 +75,7 @@ bind C-c new-session
 bind C-f command-prompt -p find-session 'switch-client -t %%'
 
 # session navigation
-bind BTab switch-client -l  # move to last session
+bind-key l switch-client -l  # move to last session
 
 # split current window horizontally
 bind - split-window -v


### PR DESCRIPTION
Many terminal emulators do not properly recognize 'BTab' (BackTab) in tmux. To improve compatibility and avoid issues with unsupported key sequences, this commit replaces 'BTab' with the 'l' key for switching to the last session.

- Changed `bind-key BTab switch-client -l` to `bind-key l switch-client -l`
- Ensured that the new keybinding works consistently across terminals
- Improved usability without requiring terminal-specific workarounds

This change provides a more reliable and user-friendly experience when toggling between sessions in tmux.

Cheers! :sparkles: 