### PR TITLE
Remove redundant _root() function : Fixes #789

### DIFF
--- a/.tmux.conf
+++ b/.tmux.conf
@@ -804,16 +804,6 @@ run 'cut -c3- "$TMUX_CONF" | sh -s _apply_configuration'
 #   printf '%s\n' "$hostname"
 # }
 #
-# _root() {
-#   pane_pid=${1:-$(tmux display -p '#{pane_pid}')}
-#   pane_tty=${2:-$(tmux display -p '#{b:pane_tty}')}
-#   root=$3
-#
-#   username=$(_username "$pane_pid" "$pane_tty" false)
-#
-#   [ "$username" = "root" ] && echo "$root"
-# }
-#
 # _uptime() {
 #   case "$_uname_s" in
 #     *Darwin*|*FreeBSD*)


### PR DESCRIPTION
Removes the redundant `_root()` function in `.tmux.conf`, as it became unnecessary after commit 5c41188.
Fixes #789.


