### PR TITLE
fix: wrong variable name to fetch tpm plugins

### DIFF
--- a/.tmux.conf
+++ b/.tmux.conf
@@ -1711,7 +1711,7 @@ run 'cut -c3- "$TMUX_CONF" | sh -s _apply_configuration'
 #     printf '%s\n' "$discovered_plugins"
 #   )
 #
-#   tpm_plugins=$(tmux show -gvq '@tpm_plugins' 2>/dev/null)
+#   tpm_plugins=$(tmux show -gvq '@plugin' 2>/dev/null)
 #   tpm_plugins=$(cat << EOF | tr ' ' '\n' | awk '/^\s*$/ {next;}; !seen[$0]++ { gsub(/^[ \t]+/,"",$0); gsub(/[ \t]+$/,"",$0); print $0 }'
 #     $tpm_plugins
 #     $(__discover_plugins "$TMUX_CONF_LOCAL")


### PR DESCRIPTION
In .tmux.conf, the function called __apply_plugins use @tpm_plugins to
fetch tmux variable. But in .tmux.conf.local use @plugin to define plugins.
I dont understand what L1715 means, but this commit now is work for me.