### PR TITLE
Fix shell code blocks in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,27 +34,27 @@ You can install Oh my tmux! at any of the following locations:
 - `~/.config/tmux`
 
 Installing in `~`:
-```
-$ cd
-$ git clone --single-branch https://github.com/gpakosz/.tmux.git
-$ ln -s -f .tmux/.tmux.conf
-$ cp .tmux/.tmux.conf.local .
+```sh
+cd
+git clone --single-branch https://github.com/gpakosz/.tmux.git
+ln -s -f .tmux/.tmux.conf
+cp .tmux/.tmux.conf.local .
 ```
 
 Installing in `$XDG_CONFIG_HOME/tmux`:
-```
-$ git clone --single-branch https://github.com/gpakosz/.tmux.git "/path/to/oh-my-tmux"
-$ mkdir -p "$XDG_CONFIG_HOME/tmux"
-$ ln -s /path/to/oh-my-tmux/.tmux.conf "$XDG_CONFIG_HOME/tmux/tmux.conf"
-$ cp /path/to/oh-my-tmux/.tmux.conf.local "$XDG_CONFIG_HOME/tmux/tmux.conf.local"
+```sh
+git clone --single-branch https://github.com/gpakosz/.tmux.git "/path/to/oh-my-tmux"
+mkdir -p "$XDG_CONFIG_HOME/tmux"
+ln -s /path/to/oh-my-tmux/.tmux.conf "$XDG_CONFIG_HOME/tmux/tmux.conf"
+cp /path/to/oh-my-tmux/.tmux.conf.local "$XDG_CONFIG_HOME/tmux/tmux.conf.local"
 ```
 
 Installing in `~/.config/tmux`:
-```
-$ git clone --single-branch https://github.com/gpakosz/.tmux.git "/path/to/oh-my-tmux"
-$ mkdir -p ~/.config/tmux
-$ ln -s /path/to/oh-my-tmux/.tmux.conf ~/.config/tmux/tmux.conf
-$ cp /path/to/oh-my-tmux/.tmux.conf.local ~/.config/tmux/tmux.conf.local
+```sh
+git clone --single-branch https://github.com/gpakosz/.tmux.git "/path/to/oh-my-tmux"
+mkdir -p ~/.config/tmux
+ln -s /path/to/oh-my-tmux/.tmux.conf ~/.config/tmux/tmux.conf
+cp /path/to/oh-my-tmux/.tmux.conf.local ~/.config/tmux/tmux.conf.local
 ```
 ⚠️ When installing `$XDG_CONFIG_HOME/tmux` or `~/.config/tmux`, the configuration
 file names don't have a leading `.` character.
@@ -85,8 +85,8 @@ Troubleshooting
     Please, try make sure no tmux client or server process is currently running.
 
     Then launch tmux with:
-    ```
-    $ tmux -f /dev/null -L test
+    ```sh
+    tmux -f /dev/null -L test
     ```
 
     Which launches a new tmux client/server pair without loading any


### PR DESCRIPTION
When copying installation shell code we were getting extra $ symbols in the beginning.
Also specified shell markup.