### PR TITLE
[install.sh] run vim flavour set in VISUAL/EDITOR

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -160,8 +160,8 @@ if [ -p /dev/stdin ]; then
             *bat*)
               self | LESS='' bat --paging always --file-name install.sh
               ;;
-            *vim*)
-              self | vim -c ':set syntax=tmux' -R -
+            *vim*) # vim, nvim, neovim ... compatible
+              self | ${VISUAL:-${EDITOR}} -c ':set syntax=tmux' -R -
               ;;
             *)
               tput smcup


### PR DESCRIPTION
This commit changes the review command to run the vim dialect defined in `$VISUAL` or `$EDITOR`. Previously this would only run `vim`, see below.

```
~ bash -c "env | grep VISUAL"
VISUAL=nvim

~ curl -fsSL "https://github.com/gpakosz/.tmux/raw/refs/heads/master/install.sh#$(date +%s)" | bash
✋ STOP
   🤨 It looks like you are piping commands from the internet to your shell!
   🙏 Please take the time to review what's going to be executed...

   Do you want to review the content? [Yes/No/Cancel] > Y
bash: line 164: vim: command not found
```

Thank you for this project.