### PR TITLE
fix: prevent recursive plugin updates when TPM bindings trigger config reload

### DIFF
--- a/.tmux.conf
+++ b/.tmux.conf
@@ -1656,8 +1656,12 @@ run 'cut -c3- "$TMUX_CONF" | sh -s _apply_configuration'
 #   tmux_conf_update_plugins_on_reload="$4"
 #   tmux_conf_uninstall_plugins_on_reload="$5"
 #
+#   # return early if we don't have a session, if we're already installing/updating tpm,
+#   # or if TPM bindings script triggered this reload (prevents recursive updates)
 #   if [ -z "$(tmux display -p '#{session_id}')" ] || [ "$(tmux show -sqv '@__apply_plugins')" = "true" ]; then
-#     # return early if we don't have a session or if we're already installing/updating tpm
+#     return 0
+#   fi
+#   if pgrep -qf 'tpm/bindings/(install|update|clean)_plugins' 2>/dev/null; then
 #     return 0
 #   fi
 #   tmux set -s '@__apply_plugins' true


### PR DESCRIPTION
## Problem

When using `<prefix> + I` (or `u` for update) to install/update plugins via TPM bindings, tmux becomes completely unresponsive (deadlock).

### Root Cause

1. TPM bindings script (`tpm/bindings/install_plugins`) executes
2. After completion, it calls `reload_tmux_environment()` which sources the config file via `tmux source-file`
3. If `tmux_conf_update_plugins_on_reload=true` (default), oh-my-tmux triggers another plugin update in `__apply_plugins()`
4. This creates a recursive loop where `source-file` → `__apply_plugins()` → TPM scripts → `source-file` → ...

### Symptoms

- Pressing `<prefix> + I` causes tmux to freeze
- Keyboard input becomes unresponsive
- Process tree shows stuck `tmux source-file` and `install_plugins` processes
- Only killing the processes externally restores functionality

## Solution

Add a check in `__apply_plugins()` to detect when TPM bindings scripts are currently running. If detected, skip the automatic plugin update to prevent the recursive loop.

```bash
if pgrep -qf 'tpm/bindings/(install|update|clean)_plugins' 2>/dev/null; then
  return 0
fi
```

This allows:
- Normal `<prefix> + I/u` to work correctly (TPM handles it directly)
- Config reload (`<prefix> + r`) to still trigger plugin updates when no TPM operation is in progress
- Launch-time plugin updates to work as expected

## Testing

1. Set `tmux_conf_update_plugins_on_reload=true` (default)
2. Add some plugins via `set -g @plugin '...'`
3. Press `<prefix> + I` to install plugins
4. **Before fix**: tmux freezes, requires external process kill
5. **After fix**: plugins install normally, tmux remains responsive