### PR TITLE
document Warp Opt-Arrow tmux workaround

### DIFF
--- a/.tmux.conf.local
+++ b/.tmux.conf.local
@@ -407,6 +407,19 @@ tmux_conf_urlscan_options="--compact --dedupe"
 # display a message after toggling mouse support
 bind m run "cut -c3- '#{TMUX_CONF}' | sh -s _toggle_mouse" \; display 'mouse #{?#{mouse},on,off}'
 
+# Warp on macOS may leak "3D" or "3C" when pressing Opt-Left / Opt-Right
+# inside tmux. The following remaps those keys to shell word movement.
+# /!\ this overrides tmux's default M-Left / M-Right pane resize bindings
+#set -s escape-time 50 #!important
+#unbind -n M-Left #!important
+#unbind -n M-Right #!important
+#bind -n M-Left send-keys Escape b #!important
+#bind -n M-Right send-keys Escape f #!important
+#set -s user-keys[0] "\e[1;3D" #!important
+#set -s user-keys[1] "\e[1;3C" #!important
+#bind -n User0 send-keys Escape b #!important
+#bind -n User1 send-keys Escape f #!important
+
 # move status line to top
 #set -g status-position top
 

--- a/README.md
+++ b/README.md
@@ -151,6 +151,28 @@ Troubleshooting
     `tmux_conf_theme_right_separator_main`
     and `tmux_conf_theme_right_separator_sub` variables.
 
+  - **Warp on macOS prints `3D` or `3C` when pressing `Opt-Left` / `Opt-Right` inside tmux**
+
+    Warp may deliver those key presses as raw xterm sequences that tmux does not
+    fully consume with the default configuration. If you want `Opt-Left` and
+    `Opt-Right` to move by word in your shell, add the following lines to your
+    `.local` customization file copy:
+
+    ```
+    set -s escape-time 50 #!important
+    unbind -n M-Left #!important
+    unbind -n M-Right #!important
+    bind -n M-Left send-keys Escape b #!important
+    bind -n M-Right send-keys Escape f #!important
+    set -s user-keys[0] "\e[1;3D" #!important
+    set -s user-keys[1] "\e[1;3C" #!important
+    bind -n User0 send-keys Escape b #!important
+    bind -n User1 send-keys Escape f #!important
+    ```
+
+    ⚠️ This trades tmux's default `M-Left` / `M-Right` pane resize bindings for
+    shell word movement.
+
 [Powerline]: https://github.com/Lokaltog/powerline
 [Powerline code points]: #enabling-the-powerline-look
 


### PR DESCRIPTION
## Summary
- document a Warp-on-macOS workaround for `Opt-Left` and `Opt-Right` leaking `3D` / `3C` inside tmux
- add the opt-in `.tmux.conf.local` snippet to the sample local config and troubleshooting docs
- note that the workaround trades tmux's default `M-Left` / `M-Right` pane resize bindings for shell word movement

## Why
Warp users hitting this issue inside tmux currently need to discover and reconstruct the workaround themselves. Documenting the local override makes the fix easier to find without changing default behavior for all users.

## Reference

### Warp issues
- https://github.com/warpdotdev/Warp/issues/4699
- https://github.com/warpdotdev/Warp/discussions/501