### PR TITLE
Change shebang to use env instead of calling bash directly

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 # Oh my tmux!
 # 💛🩷💙🖤❤️🤍
 # https://github.com/gpakosz/.tmux


### PR DESCRIPTION
Some systems might not have bash at `/bin/bash`. the `env` command is almost always at `/usr/bin/env` and will execute the bash that appears first in `$PATH`