### PR TITLE
fix TPM plugin loading during initial startup

### DIFF
--- a/.tmux.conf
+++ b/.tmux.conf
@@ -1666,6 +1666,12 @@ run 'cut -c3- "$TMUX_CONF" | sh -s _apply_configuration'
 #   tmux_conf_update_plugins_on_reload="$4"
 #   tmux_conf_uninstall_plugins_on_reload="$5"
 #
+#   # wait for session to become available (handles run -b timing on startup)
+#   _wait_count=0
+#   while [ -z "$(tmux display -p '#{session_id}' 2>/dev/null)" ] && [ "$_wait_count" -lt 50 ]; do
+#     sleep 0.1
+#     _wait_count=$((_wait_count + 1))
+#   done
 #   if [ -z "$(tmux display -p '#{session_id}')" ] || [ "$(tmux show -sqv '@__apply_plugins')" = "true" ]; then
 #     # return early if we don't have a session or if we're already installing/updating tpm
 #     return 0


### PR DESCRIPTION
# Fix TPM plugin loading race on initial tmux startup

## Problem

TPM plugins configured in `.tmux.conf.local` are not loaded on fresh tmux startup. They only load after a manual config reload (`prefix + r`).

Reproduced on tmux `3.2a` and `next-3.7`, on Ubuntu 22.04.5 LTS (WSL2, zsh).

## Root Cause

`_apply_plugins()` schedules `__apply_plugins()` via `tmux run -b`. On initial startup, the background job can execute before the session is fully created, causing `tmux display -p '#{session_id}'` to return empty. The existing guard then bails out before TPM is loaded.

On reload the session already exists, so the guard passes and plugins load fine.

## Fix

Add a retry loop before the existing guard that waits for the session to become available (polls every 100ms, up to ~5s):

```sh
_wait_count=0
while [ -z "$(tmux display -p '#{session_id}' 2>/dev/null)" ] && [ "$_wait_count" -lt 50 ]; do
  sleep 0.1
  _wait_count=$((_wait_count + 1))
done
```

- Normal startup: session appears within ~200-500ms, loop exits early
- Reload: session exists, loop exits immediately
- Still runs inside `tmux run -b`, never blocks tmux
