### PR TITLE
fix: preserve full-width prompts on tmux 3.7

### DIFF
--- a/.tmux.conf
+++ b/.tmux.conf
@@ -1178,6 +1178,13 @@ run 'cut -c3- "$TMUX_CONF" | sh -s _apply_configuration'
 #     tmux_conf_theme_message_command_bg=${tmux_conf_theme_message_command_bg:-$tmux_conf_theme_colour_1}
 #     tmux_conf_theme_message_command_attr=${tmux_conf_theme_message_command_attr:-bold}
 #
+#     message_style="fg=$tmux_conf_theme_message_fg,bg=$tmux_conf_theme_message_bg,$tmux_conf_theme_message_attr"
+#     message_command_style="fg=$tmux_conf_theme_message_command_fg,bg=$tmux_conf_theme_message_command_bg,$tmux_conf_theme_message_command_attr"
+#     if [ "$_tmux_version" -ge 3700 ]; then
+#       message_style="$message_style,fill=$tmux_conf_theme_message_bg"
+#       message_command_style="$message_command_style,fill=$tmux_conf_theme_message_command_bg"
+#     fi
+#
 #     tmux_conf_theme_mode_fg=${tmux_conf_theme_mode_fg:-$tmux_conf_theme_colour_1}
 #     tmux_conf_theme_mode_bg=${tmux_conf_theme_mode_bg:-$tmux_conf_theme_colour_5}
 #     tmux_conf_theme_mode_attr=${tmux_conf_theme_mode_attr:-bold}
@@ -1446,8 +1453,8 @@ run 'cut -c3- "$TMUX_CONF" | sh -s _apply_configuration'
 #     tmux setw -g window-style "$window_style" \; setw -g window-active-style "$window_active_style" \;\
 #          setw -g pane-border-style "fg=$tmux_conf_theme_pane_border_fg,bg=$tmux_conf_theme_pane_border_bg" \; set -g pane-active-border-style "fg=$tmux_conf_theme_pane_active_border_fg,bg=$tmux_conf_theme_pane_active_border_bg" \;\
 #          set -g display-panes-colour "$tmux_conf_theme_pane_indicator" \; set -g display-panes-active-colour "$tmux_conf_theme_pane_active_indicator" \;\
-#          set -g message-style "fg=$tmux_conf_theme_message_fg,bg=$tmux_conf_theme_message_bg,$tmux_conf_theme_message_attr" \;\
-#          set -g message-command-style "fg=$tmux_conf_theme_message_command_fg,bg=$tmux_conf_theme_message_command_bg,$tmux_conf_theme_message_command_attr" \;\
+#          set -g message-style "$message_style" \;\
+#          set -g message-command-style "$message_command_style" \;\
 #          setw -g mode-style "fg=$tmux_conf_theme_mode_fg,bg=$tmux_conf_theme_mode_bg,$tmux_conf_theme_mode_attr" \;\
 #          set -g status-style "fg=$tmux_conf_theme_status_fg,bg=$tmux_conf_theme_status_bg,$tmux_conf_theme_status_attr" \;\
 #          set -g status-left-style "fg=$tmux_conf_theme_status_fg,bg=$tmux_conf_theme_status_bg,$tmux_conf_theme_status_attr" \;\


### PR DESCRIPTION
tmux 3.7 changed messages and prompts to overlay the existing status line. Custom message styles must now specify `fill` to retain the previous full-width behavior, but this theme overrides the new tmux defaults without carrying that attribute forward.

Build both message styles once and append a fill matching each background on tmux 3.7 and later. Keep earlier releases unchanged because this project supports tmux 2.6, where `fill` is not recognized.

The opaque fill also avoids the stale prompt redraw path reported upstream when editing a window name.

Updates tmux/tmux#4861
Updates tmux/tmux#5328